### PR TITLE
Add reusable workflow

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,8 +43,8 @@ jobs:
             echo "Environment is not set"
           fi
 
-      - name: deploy
-        if: env.ENVIRONMENT
-        uses: ./.github/workflows/reusable-deployment-workflow.yml
-        with:
-          environment: env.ENVIRONMENT
+  deploy:
+    if: env.ENVIRONMENT
+    uses: ./.github/workflows/reusable-deployment-workflow.yml
+    with:
+      environment: env.ENVIRONMENT

--- a/.github/workflows/deploy-to-dev-using-directory.yaml
+++ b/.github/workflows/deploy-to-dev-using-directory.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: deploy
-        if: env.ENVIRONMENT
-        uses: ./.github/workflows/reusable-deployment-workflow.yml
-        with:
-          environment: env.ENVIRONMENT
+  deploy:
+    if: env.ENVIRONMENT
+    uses: ./.github/workflows/reusable-deployment-workflow.yml
+    with:
+      environment: env.ENVIRONMENT

--- a/.github/workflows/deploy-to-prd-using-directory.yaml
+++ b/.github/workflows/deploy-to-prd-using-directory.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: deploy
-        if: env.ENVIRONMENT
-        uses: ./.github/workflows/reusable-deployment-workflow.yml
-        with:
-          environment: env.ENVIRONMENT
+  deploy:
+    if: env.ENVIRONMENT
+    uses: ./.github/workflows/reusable-deployment-workflow.yml
+    with:
+      environment: env.ENVIRONMENT

--- a/.github/workflows/deploy-to-stg-using-directory.yaml
+++ b/.github/workflows/deploy-to-stg-using-directory.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: deploy
-        if: env.ENVIRONMENT
-        uses: ./.github/workflows/reusable-deployment-workflow.yml
-        with:
-          environment: env.ENVIRONMENT
+  deploy:
+    if: env.ENVIRONMENT
+    uses: ./.github/workflows/reusable-deployment-workflow.yml
+    with:
+      environment: env.ENVIRONMENT

--- a/staging/dummy.txt
+++ b/staging/dummy.txt
@@ -1,1 +1,1 @@
-This is a change in staging!
+This is a change in staging!!


### PR DESCRIPTION
Fixed indentation in workflows so that github actions interprets it as a reusable workflow instead of treating it as an action. In order to do this you can simply use the `uses` keyword on a job level instead of on a step level.